### PR TITLE
Added accent as a separate optional parameter to language

### DIFF
--- a/xtts_api_server/server.py
+++ b/xtts_api_server/server.py
@@ -53,7 +53,7 @@ MODEL_VERSION = XTTS.model_version
 # Create version string
 version_string = ""
 if MODEL_SOURCE == "api" or MODEL_VERSION == "main":
-    version_string = "lastest"
+    version_string = "latest"
 else:
     version_string = MODEL_VERSION
 
@@ -136,6 +136,7 @@ class SynthesisRequest(BaseModel):
     text: str
     speaker_wav: Optional[str] = None
     language: str
+    accent: Optional[str] = None
     save_path: Optional[str] = None
 
 class SynthesisFileRequest(BaseModel):
@@ -310,6 +311,7 @@ async def tts_to_audio(request: SynthesisRequest, background_tasks: BackgroundTa
                 text=request.text,
                 speaker_name_or_path=request.speaker_wav,
                 language=request.language.lower(),
+                accent=request.accent,
                 file_name_or_path=request.save_path
             )
             


### PR DESCRIPTION
Added accent as a unique parameter to call the XTTS server. The existing `language` parameter is used to:
1. Find the correct voice latent to use (eg `latent_speaker_folder/ar`, `latent_speaker_folder/en` etc)
2. Inform XTTS of the language of a given voiceline. 

By having a unique accent parameter, the latter of these two applications can be overriden to "trick" XTTS into applying an "accent" to a given voiceline, while keeping the underlying voice latent the same. This fixes an issue with Mantella where applying an accent causes the XTTS server to search for a voice latent in the given accent's voice folder when this accent doesn't exist.